### PR TITLE
tweak travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.11'
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm@^2"


### PR DESCRIPTION
- ensure we have npm 2.x
- disable npm spinner
- display updated versions of things before running tests

as usual, we can blame NPM for the failed tests.
