### PR TITLE
Upgrade to Babel 5.0.0-beta3; avoid ANSI sequences in error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,15 +24,11 @@ Babel.prototype.transform = function(string, options) {
 };
 
 Babel.prototype.processString = function (string, relativePath) {
-  var options = this.copyOptions();
+  var options = clone(this.options);
 
   options.filename = options.sourceMapName = options.sourceFileName = relativePath;
 
   return this.transform(string, options).code;
-};
-
-Babel.prototype.copyOptions = function() {
-  return clone(this.options);
 };
 
 module.exports = Babel;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/babel/broccoli-babel-transpiler",
   "dependencies": {
-    "babel-core": "^4.0.0",
+    "babel-core": "^5.0.0-beta3",
     "broccoli-filter": "^0.1.7",
     "clone": "^0.2.0"
   },


### PR DESCRIPTION
<strike>Before you merge: The Babel version 5.0.0-beta3 that this PR depends on doesn't exist on npm yet; we need a Babel release (due to https://github.com/babel/babel/pull/1102) before this can work. :)</strike>

There is one failing test, but it was already failing on master; there doesn't seem to be a regression.