### PR TITLE
Defer to super implementation Filter#cacheKeyProcessString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ Babel.prototype.baseDir = function() {
  */
 
 Babel.prototype.cacheKeyProcessString = function(string, relativePath) {
-  return this.optionsHash() + crypto.createHash('md5').update(string, 'utf8').digest('hex');
+  return this.optionsHash() + Filter.prototype.cacheKeyProcessString.call(this, string, relativePath);
 };
 
 /* @public


### PR DESCRIPTION
This begs the question to me, why can't `broccoli-persistent-filter` have `optionsHash()` implementation by default as well and assign `this.options`? Or even `broccoli-filter`...why doesn't *it* assign `this.options`?

Basically, just starting this PR to discuss how we can reduce the boilerplate required to use `broccoli-persistent-filter` and since this is the first consumer, seems appropriate to discuss here.