### PR TITLE
[proposal] browserPolyfill option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ var scriptTree = esTranspiler(inputTree, {
 ```
 
 `exportModuleMetadata` is an option that can be used to write a JSON file to the output tree that gives you metadata about the tree's imports and exports.
+
+## Polyfill
+
+In order to use some of the ES6 features you must include the Babel [polyfill](http://babeljs.io/docs/usage/polyfill/#usage-in-browser).
+
+You don't always need this, review which features need the polyfill here: [ES6 Features](https://babeljs.io/docs/learn-es6).
+
+```js
+var esTranspiler = require('broccoli-babel-transpiler');
+var scriptTree = esTranspiler(inputTree, { browserPolyfill: true });
+```
+

--- a/README.md
+++ b/README.md
@@ -62,4 +62,3 @@ You don't always need this, review which features need the polyfill here: [ES6 F
 var esTranspiler = require('broccoli-babel-transpiler');
 var scriptTree = esTranspiler(inputTree, { browserPolyfill: true });
 ```
-

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function Babel(inputTree, options) {
     delete this.options.exportModuleMetadata;
   }
 
-  if ( this.options.browserPolyfill ) {
+  if (this.options.browserPolyfill) {
     delete this.options.browserPolyfill;
 
     var babelCorePath = require.resolve('babel-core');

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var clone      = require('clone');
 var path       = require('path');
 var fs         = require('fs');
 var stringify  = require('json-stable-stringify');
+var mergeTrees = require('broccoli-merge-trees');
+var funnel = require('broccoli-funnel');
 
 function getExtensionsRegex(extensions) {
   return extensions.map(function(extension) {
@@ -38,6 +40,15 @@ function Babel(inputTree, options) {
     // Note, Babel does not support this option so we must save it then
     // delete it from the options hash
     delete this.options.exportModuleMetadata;
+  }
+
+  if ( this.options.browserPolyfill ) {
+    delete this.options.browserPolyfill;
+    var src = 'node_modules/broccoli-babel-transpiler/node_modules/babel-core';
+    var polyfill = funnel(src, { files: ['browser-polyfill.js'] });
+    this.inputTree = mergeTrees([polyfill, inputTree]);
+  } else {
+    this.inputTree = inputTree;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -44,8 +44,11 @@ function Babel(inputTree, options) {
 
   if ( this.options.browserPolyfill ) {
     delete this.options.browserPolyfill;
-    var src = 'node_modules/broccoli-babel-transpiler/node_modules/babel-core';
-    var polyfill = funnel(src, { files: ['browser-polyfill.js'] });
+
+    var babelCorePath = require.resolve('babel-core');
+    babelCorePath = babelCorePath.replace(/\/babel-core\/.*$/, '/babel-core');
+
+    var polyfill = funnel(babelCorePath, { files: ['browser-polyfill.js'] });
     this.inputTree = mergeTrees([polyfill, inputTree]);
   } else {
     this.inputTree = inputTree;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "babel-core": "^5.0.0",
     "json-stable-stringify": "^1.0.0",
     "cauliflower-filter": "^1.0.4",
+    "broccoli-funnel": "^0.2.3",
+    "broccoli-merge-trees": "^0.2.1",
     "clone": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The current implementation is just a quick and dirty patch.

1. Having this option in the plugin is something that will be accepted?
2. How I see it happening is:
 1. have the plugin be an object/plugin of its own instead of extending from `broccoli-filter`
 2. do the transpilation, build a transpiled tree internally for further processing
 3. if `browserPolyfill` is set, prepend the polyfill to the transpiled tree and just then return it