### PR TITLE
Introduce Module Metadata export

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ separate source map feature, you're welcome to submit a pull request.
 
 ## Advanced usage
 
-`filterExtensions` is an option to limit (or expand) the set of file extensions that
-will be transformed.
+`filterExtensions` is an option to limit (or expand) the set of file extensions that will be transformed.
 
 The default `filterExtension` is `js`
 
@@ -41,3 +40,5 @@ var scriptTree = esTranspiler(inputTree, {
     filterExtensions:['js', 'es6'] // babelize both .js and .es6 files
 });
 ```
+
+`exportMetadata` is an option that can be used to write a JSON file to the output tree that gives you metadata about the tree's imports and exports.

--- a/fixtures/dep-graph.json
+++ b/fixtures/dep-graph.json
@@ -1,0 +1,96 @@
+{
+  "expected": {
+    "exports": {
+      "exported": [
+      ],
+      "specifiers": [
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "expected-inline-source-maps": {
+    "exports": {
+      "exported": [
+      ],
+      "specifiers": [
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "fixtures": {
+    "exports": {
+      "exported": [
+      ],
+      "specifiers": [
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "named-module": {
+    "exports": {
+      "exported": [
+      ],
+      "specifiers": [
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "named-module-fixture": {
+    "exports": {
+      "exported": [
+        "foo",
+        "bar"
+      ],
+      "specifiers": [
+        {
+          "exported": "foo",
+          "kind": "local",
+          "local": "foo"
+        },
+        {
+          "exported": "bar",
+          "kind": "local",
+          "local": "bar"
+        }
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "true-module": {
+    "exports": {
+      "exported": [
+      ],
+      "specifiers": [
+      ]
+    },
+    "imports": [
+    ]
+  },
+  "true-module-fixture": {
+    "exports": {
+      "exported": [
+        "foo",
+        "bar"
+      ],
+      "specifiers": [
+        {
+          "exported": "foo",
+          "kind": "local",
+          "local": "foo"
+        },
+        {
+          "exported": "bar",
+          "kind": "local",
+          "local": "bar"
+        }
+      ]
+    },
+    "imports": [
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "babel-core": "^5.0.0",
     "broccoli-filter": "^0.1.7",
-    "clone": "^0.2.0"
+    "clone": "^0.2.0",
+    "json-stable-stringify": "^1.0.0"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",

--- a/test.js
+++ b/test.js
@@ -206,3 +206,20 @@ describe('filters files to transform', function() {
     });
   });
 });
+
+describe('module metadata', function() {
+  it('exports module metadata', function() {
+    return build(inputPath, {
+      exportModuleMetadata: true,
+      moduleId: true,
+      modules: 'amdStrict',
+      sourceMap: false,
+      inputSourceMap: false
+    }).then(function(results) {
+      var outputPath = results.directory;
+      var output = fs.readFileSync(path.join(outputPath , 'dep-graph.json'), 'utf8');
+      var expectation = fs.readFileSync(path.join(inputPath, 'dep-graph.json'), 'utf8');
+      expect(output).to.eql(expectation);
+    });
+  });
+});


### PR DESCRIPTION
This allows for a JSON file to be written into the tree that describes the modules in the tree. This JSON file can then be used to perform dependency graph resolution. /cc @stefanpenner 