### PR TITLE
Use cauliflower-filter for stable paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,7 @@ function Babel(inputTree, options) {
 
 Babel.prototype = Object.create(Filter.prototype);
 Babel.prototype.constructor = Babel;
-
-Babel.prototype.extensions = ['js'];
-Babel.prototype.targetExtension = 'js';
+Babel.prototype.targetExtension = ['js'];
 
 Babel.prototype.write = function(readTree, destDir) {
   var self = this;

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "dependencies": {
     "babel-core": "^5.0.0",
     "broccoli-filter": "^0.1.7",
-    "clone": "^0.2.0",
-    "json-stable-stringify": "^1.0.0"
+    "json-stable-stringify": "^1.0.0",
+    "cauliflower-filter": "^1.0.3",
+    "clone": "^0.2.0"
   },
   "devDependencies": {
-    "broccoli": "^0.13.3",
-    "broccoli-cli": "0.0.1",
+    "broccoli": "^0.16.3",
     "chai": "^1.10.0",
     "mocha": "^1.21.4",
     "rimraf": "^2.2.8"


### PR DESCRIPTION
Prior to this commit output and input paths were unstable due to the fact broccoli-filter did not use the broccoli rebuild api.