### PR TITLE
Stick Cauliflower-filter at 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "babel-core": "^5.0.0",
     "json-stable-stringify": "^1.0.0",
-    "cauliflower-filter": "^1.0.3",
+    "cauliflower-filter": "^1.0.4",
     "clone": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
South of 1.0.4 there was a bug where directories would get written to CWD. In 1.0.4 that is fixed. See https://github.com/caitp/cauliflower-filter/pull/9 for more details.