### PR TITLE
Ensure import names are the same

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ Babel.prototype.processString = function (string, relativePath) {
   var key = options.moduleId ? options.moduleId : relativePath;
 
   if (transpiled.metadata && transpiled.metadata.modules) {
-    this.moduleMetadata[key] = transpiled.metadata.modules;
+    this.moduleMetadata[byImportName(key)] = transpiled.metadata.modules;
   }
 
   return transpiled.code;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "broccoli-test-helpers": "0.0.8",
     "chai": "^1.10.0",
     "mocha": "^1.21.4",
+    "mock-fs": "^3.0.0",
     "rimraf": "^2.2.8"
   }
 }


### PR DESCRIPTION
Prior to this commit it was possible to have `imports` and the files in
the cache to differ based on options passed into Babel. This commit
makes sure we are always dealing with extensionless names.