### PR TITLE
Adding name property

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function Babel(inputTree, options) {
   this.moduleMetadata = {};
   this.extensions = this.options.filterExtensions || ['js'];
   this.extensionsRegex = getExtensionsRegex(this.extensions);
+  this.name = 'broccoli-babel-transpiler';
 
   if (this.options.exportModuleMetadata) {
     this.exportModuleMetadata = this.options.exportModuleMetadata;


### PR DESCRIPTION
This allows devs to effectively debug and undstand where cache hits are
coming from.