### PR TITLE
Ignore Windows newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ Babel.prototype.transform = function(string, options) {
  * @method optionsString
  * @returns a stringifeid version of the input options
  */
-Babel.prototype.optionsHash  = function() {
+Babel.prototype.optionsHash = function() {
   if (!this._optionsHash) {
     this._optionsHash = crypto.createHash('md5').update(stringify(this.options), 'utf8').digest('hex');
   }
@@ -111,7 +111,7 @@ Babel.prototype.cacheKeyProcessString = function(string, relativePath) {
   return this.optionsHash() + Filter.prototype.cacheKeyProcessString.call(this, string, relativePath);
 };
 
-Babel.prototype.processString = function (string, relativePath) {
+Babel.prototype.processString = function(string, relativePath) {
   var options = this.copyOptions();
 
   options.filename = options.sourceMapName = options.sourceFileName = relativePath;

--- a/test.js
+++ b/test.js
@@ -17,6 +17,12 @@ var expectations = path.join(__dirname, 'expectations');
 
 var babel;
 
+function readFileSync() {
+  // babel doesn't support Windows newlines
+  // https://github.com/babel/babel/pull/2290
+  return fs.readFileSync.apply(this, arguments).replace(/\r\n/g, '\n');
+}
+
 describe('options', function() {
   var options;
 
@@ -125,8 +131,8 @@ describe('transpile ES6 to ES5', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'fixtures.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'expected.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'fixtures.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'expected.js'), 'utf8');
 
       expect(output).to.eql(input);
     });
@@ -138,8 +144,8 @@ describe('transpile ES6 to ES5', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'fixtures.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'expected-inline-source-maps.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'fixtures.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'expected-inline-source-maps.js'), 'utf8');
 
       expect(output).to.eql(input);
     });
@@ -168,8 +174,8 @@ describe('filters files to transform', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'fixtures.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'expected.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'fixtures.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'expected.js'), 'utf8');
 
       expect(output).to.eql(input);
       // Verify that .es6 file was not transformed
@@ -186,8 +192,8 @@ describe('filters files to transform', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'fixtures-es6.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'expected.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'fixtures-es6.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'expected.js'), 'utf8');
 
       expect(output).to.eql(input);
       // Verify that .es6 file was not transformed
@@ -204,9 +210,9 @@ describe('filters files to transform', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var es6ExtOutput = fs.readFileSync(path.join(outputPath, 'fixtures-es6.js')).toString();
-      var jsExtOutput = fs.readFileSync(path.join(outputPath, 'fixtures.js')).toString();
-      var input = fs.readFileSync(path.join(expectations, 'expected.js')).toString();
+      var es6ExtOutput = readFileSync(path.join(outputPath, 'fixtures-es6.js'), 'utf8');
+      var jsExtOutput = readFileSync(path.join(outputPath, 'fixtures.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'expected.js'), 'utf8');
 
       expect(es6ExtOutput).to.eql(input);
       expect(jsExtOutput).to.eql(input);
@@ -224,8 +230,8 @@ describe('filters files to transform', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'named-module-fixture.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'named-module.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'named-module-fixture.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'named-module.js'), 'utf8');
 
       expect(output).to.eql(input);
     });
@@ -241,8 +247,8 @@ describe('filters files to transform', function() {
     }).then(function(results) {
       var outputPath = results.directory;
 
-      var output = fs.readFileSync(path.join(outputPath, 'true-module-fixture.js')).toString();
-      var input = fs.readFileSync(path.join(expectations,  'true-module.js')).toString();
+      var output = readFileSync(path.join(outputPath, 'true-module-fixture.js'), 'utf8');
+      var input = readFileSync(path.join(expectations, 'true-module.js'), 'utf8');
 
       expect(output).to.eql(input);
     });
@@ -272,8 +278,8 @@ describe('filters files to transform', function() {
 //       inputSourceMap: false
 //     }).then(function(results) {
 //       var outputPath = results.directory;
-//       var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-//       var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
+//       var output = readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
+//       var expectation = readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
 //       expect(output).to.eql(expectation);
 //     });
 //   });
@@ -288,8 +294,8 @@ describe('filters files to transform', function() {
 //     }).then(function(results) {
 //       // Normal build
 //       var outputPath = results.directory;
-//       var output = fs.readFileSync(path.join(outputPath , 'dep-graph.json'), 'utf8');
-//       var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
+//       var output = readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
+//       var expectation = readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
 //       expect(output).to.eql(expectation);
 
 //       // Move away files/fixtures.js
@@ -301,16 +307,16 @@ describe('filters files to transform', function() {
 
 //       // Build without files/fixtures.js
 //       var outputPath = results.directory;
-//       var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-//       var expectation = fs.readFileSync(path.join(expectations, 'pruned-dep-graph.json'), 'utf8');
+//       var output = readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
+//       var expectation = readFileSync(path.join(expectations, 'pruned-dep-graph.json'), 'utf8');
 //       expect(output).to.eql(expectation);
 
 //       return results.builder();
 //     }).then(function(results) {
 //       // Back to the first build
 //       var outputPath = results.directory;
-//       var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-//       var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
+//       var output = readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
+//       var expectation = readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
 //       expect(output).to.eql(expectation);
 //     });
 //   });
@@ -340,7 +346,7 @@ describe('filters files to transform', function() {
 
 //       babel._generateDepGraph();
 
-//       expect(fs.readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
+//       expect(readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
 //         bar: {},
 //         foo: {}
 //       }, { space: 2 }));
@@ -357,7 +363,7 @@ describe('filters files to transform', function() {
 
 //       babel._generateDepGraph();
 
-//       expect(fs.readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
+//       expect(readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
 //         foo: {}
 //       }, { space: 2 }));
 //     });


### PR DESCRIPTION
Almost fixes #54. One other issue remains.
It doesn't look like Windows support is coming anytime soon upstream babel/babel/pull/2290, so we need to force the Unix newline.