### PR TITLE
Allow targetExtesion to be passed in as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ var scriptTree = esTranspiler(inputTree, {
 });
 ```
 
+`targetExtension` is an option to specify the extension of the output files
+
+The default `targetExtension` is `js`
+
+```js
+var esTranspiler = require('broccoli-babel-transpiler');
+var scriptTree = esTranspiler(inputTree, {
+    targetExtension: 'module.js' // create output files with module.js extension
+});
+```
+
 ## Polyfill
 
 In order to use some of the ES6 features you must include the Babel [polyfill](http://babeljs.io/docs/usage/polyfill/#usage-in-browser).

--- a/index.js
+++ b/index.js
@@ -192,6 +192,9 @@ Babel.prototype.copyOptions = function() {
   if (cloned.filterExtensions) {
     delete cloned.filterExtensions;
   }
+  if (cloned.targetExtension) {
+    delete cloned.targetExtension;
+  }
   return cloned;
 };
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function Babel(inputTree, _options) {
 
 Babel.prototype = Object.create(Filter.prototype);
 Babel.prototype.constructor = Babel;
-Babel.prototype.targetExtension = ['js'];
+Babel.prototype.targetExtension = 'js';
 
 Babel.prototype.baseDir = function() {
   return __dirname;

--- a/test.js
+++ b/test.js
@@ -86,7 +86,7 @@ describe('options', function() {
     expect(transpilerOptions.moduleId).to.eql('relativePath');
   });
 
-  it('does not propagate validExtensions', function () {
+  it('does not propagate filterExtensions', function () {
     var transpilerOptions;
 
     babel.transform = function(string, options) {

--- a/test.js
+++ b/test.js
@@ -25,7 +25,8 @@ describe('options', function() {
       bar: {
         baz: 1
       },
-      filterExtensions: ['es6']
+      filterExtensions: ['es6'],
+      targetExtension: 'js'
     };
 
     babel = new Babel('foo', options);
@@ -98,6 +99,20 @@ describe('options', function() {
     babel.processString('path', 'relativePath');
 
     expect(transpilerOptions.filterExtensions).to.eql(undefined);
+  });
+
+  it('does not propagate targetExtension', function () {
+    var transpilerOptions;
+
+    babel.transform = function(string, options) {
+      transpilerOptions = options;
+      return { code: {} };
+    };
+
+    expect(transpilerOptions).to.eql(undefined);
+    babel.processString('path', 'relativePath');
+
+    expect(transpilerOptions.targetExtension).to.eql(undefined);
   });
 });
 


### PR DESCRIPTION
I was trying to pass in the targetExtension option and I was getting a `Unknown option: direct.targetExtension` error. This should fix that
