### PR TITLE
Update .Travis.yml to Latest Node and NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
+  - "5.5"
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@^3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
+    - nodejs_version: "5.5"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Current further builds are failing on Node 0.12 and NPM 2.

This updates to latest node.js

This also will allow for #73 to be passing all tests.