### PR TITLE
Unable to disable persist with documented `persist` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ function Babel(inputTree, _options) {
   }
 
   var options = _options || {};
-  options.persist = !options.exportModuleMetadata; // TODO: make this also work in cache
+  
+  if (options.persist === undefined)
+    options.persist = !options.exportModuleMetadata; // TODO: make this also work in cache
+  }
+
   Filter.call(this, inputTree, options);
 
   delete options.persist;


### PR DESCRIPTION
This allows passing `persist: false` for the cases where you want to disable persisting.