### PR TITLE
Allow passing persist option w/o overriding it

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ function Babel(inputTree, _options) {
   }
 
   var options = _options || {};
-  options.persist = !options.exportModuleMetadata; // TODO: make this also work in cache
+
+  if (options.persist === undefined) {
+    options.persist = !options.exportModuleMetadata; // TODO: make this also work in cache
+  }
+
   Filter.call(this, inputTree, options);
 
   delete options.persist;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-babel-transpiler",
-  "version": "5.4.5",
+  "version": "5.5.0",
   "description": "A Broccoli plugin which transpile ES6 to readable ES5 by using babel.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Depending on the environment in which I run my builder (test vs development + production) I implement `getModuleId` slightly different.  This results in the method to being invoked in tests due to the cache persisting.  For test builds, I need the ability to opted-out of persistance.
