### PR TITLE
[BUGFIX] cache not clearing reliably when modifying options

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,9 +101,19 @@ Babel.prototype.transform = function(string, options) {
  * @returns a stringifeid version of the input options
  */
 Babel.prototype.optionsHash = function() {
+  var options = this.options;
+  var hash = {};
+  var key, value;
+
   if (!this._optionsHash) {
-    this._optionsHash = crypto.createHash('md5').update(stringify(this.options), 'utf8').digest('hex');
+    for (key in options) {
+      value = options[key];
+      hash[key] = (typeof value === 'function') ? (value + '') : value;
+    }
+
+    this._optionsHash = crypto.createHash('md5').update(stringify(hash), 'utf8').digest('hex');
   }
+
   return this._optionsHash;
 };
 

--- a/test.js
+++ b/test.js
@@ -388,3 +388,46 @@ describe('consume broccoli-babel-transpiler options', function() {
     expect(code).to.be.ok;
   });
 });
+
+describe('when options change', function() {
+  var originalHash, options;
+
+  beforeEach(function() {
+    options = {
+      bar: 1,
+      baz: function() {}
+    };
+
+    var babel = new Babel('foo', options);
+
+    originalHash = babel.optionsHash();
+  });
+
+  it('clears cache for added properties', function() {
+    options.foo = 1;
+    var babelNew = new Babel('foo', options);
+
+    expect(babelNew.optionsHash()).to.not.eql(originalHash);
+  });
+
+  it('clears cache for updated properties', function() {
+    options.bar = 2;
+    var babelNew = new Babel('foo', options);
+
+    expect(babelNew.optionsHash()).to.not.eql(originalHash);
+  });
+
+  it('clears cache for added methods', function() {
+    options.foo = function() {};
+    var babelNew = new Babel('foo', options);
+
+    expect(babelNew.optionsHash()).to.not.eql(originalHash);
+  });
+
+  it('clears cache for updated methods', function() {
+    options.baz = function() { return 1; };
+    var babelNew = new Babel('foo', options);
+
+    expect(babelNew.optionsHash()).to.not.eql(originalHash);
+  });   
+});


### PR DESCRIPTION
I was having hack of a time getting the expected output as I was modifying the option's method, `resolveModuleSource`. 

