### PR TITLE
Allow plugins to bust the cache.

### DIFF
--- a/fixtures/plugin-a/index.js
+++ b/fixtures/plugin-a/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function() {
+  return 'plugin-a goes here but this isnt in plugin-b';
+};

--- a/fixtures/plugin-a/package.json
+++ b/fixtures/plugin-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/fixtures/plugin-b/index.js
+++ b/fixtures/plugin-b/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function() {
+  return 'plugin-b';
+};

--- a/fixtures/plugin-b/package.json
+++ b/fixtures/plugin-b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-b",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "clone": "^0.2.0",
+    "hash-for-dep": "^1.0.2",
     "json-stable-stringify": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a backport of #89 to the v5.x branch.