### PR TITLE
Introduce helper whitelist

### DIFF
--- a/expectations/classes.js
+++ b/expectations/classes.js
@@ -1,0 +1,21 @@
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let Bar = function Bar() {
+  _classCallCheck(this, Bar);
+};
+
+export let Foo = function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/fixtures/files/fixtures-classes.js
+++ b/fixtures/files/fixtures-classes.js
@@ -1,0 +1,3 @@
+class Bar {}
+
+export class Foo extends Bar {}

--- a/index.js
+++ b/index.js
@@ -48,9 +48,15 @@ function Babel(inputTree, _options) {
   if (this.options.exportModuleMetadata) {
     this.exportModuleMetadata = this.options.exportModuleMetadata;
   }
+
+  if (this.options.helperWhiteList) {
+    this.helperWhiteList = this.options.helperWhiteList;
+  }
+
   // Note, Babel does not support this option so we must save it then
   // delete it from the options hash
   delete this.options.exportModuleMetadata;
+  delete this.options.helperWhiteList;
 
   if (this.options.browserPolyfill) {
     var babelCorePath = require.resolve('babel-core');
@@ -198,6 +204,14 @@ Babel.prototype.processString = function(string, relativePath) {
   var transpiled = this.transform(string, options);
   var key = options.moduleId ? options.moduleId : relativePath;
 
+  if (this.helperWhiteList) {
+    var invalidHelpers = transpiled.metadata.usedHelpers.filter(function(helper) {
+      return this.helperWhiteList.indexOf(helper) === -1;
+    }, this);
+
+    validateHelpers(invalidHelpers, relativePath);
+  }
+
   if (transpiled.metadata && transpiled.metadata.modules) {
     this.moduleMetadata[byImportName(key)] = transpiled.metadata.modules;
   }
@@ -223,6 +237,28 @@ function diff(array, exclusions) {
       return item === exclude;
     });
   });
+}
+
+function validateHelpers(invalidHelpers, relativePath) {
+  if (invalidHelpers.length > 0) {
+    var message = relativePath + ' was transformed and relies on `' + invalidHelpers[0] + '`, which was not included in the helper whitelist. Either add this helper to the whitelist or refactor to not be dependent on this runtime helper.';
+
+    if (invalidHelpers.length > 1) {
+      var helpers = invalidHelpers.map(function(item, i) {
+        if (i === invalidHelpers.length - 1) {
+          return '& `' + item;
+        } else if (i === invalidHelpers.length - 2) {
+          return item + '`, ';
+        }
+
+        return item + '`, `';
+      }).join('');
+
+      message = relativePath + ' was transformed and relies on `' + helpers + '`, which were not included in the helper whitelist. Either add these helpers to the whitelist or refactor to not be dependent on these runtime helper.';
+    }
+
+    throw new Error(message);
+  }
 }
 
 module.exports = Babel;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "babel-plugin-transform-es2015-block-scoping": "^6.4.0",
+    "babel-plugin-transform-es2015-classes": "^6.9.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.4.3",
     "babel-plugin-transform-strict-mode": "^6.3.13",
     "broccoli": "^0.16.3",

--- a/test.js
+++ b/test.js
@@ -273,6 +273,36 @@ describe('filters files to transform', function() {
       expect(output).to.eql(input);
     });
   });
+
+  it('throws if a single helper is not whitelisted', function() {
+    return babel('files', {
+      helperWhiteList: ['classCallCheck', 'possibleConstructorReturn'],
+      plugins: ['transform-es2015-classes']
+    }).catch(function(err) {
+      expect(err.message).to.equal('fixtures-classes.js was transformed and relies on `inherits`, which was not included in the helper whitelist. Either add this helper to the whitelist or refactor to not be dependent on this runtime helper.');
+    });
+  });
+
+  it('throws if multiple helpers are not whitelisted', function() {
+    return babel('files', {
+      helperWhiteList: [],
+      plugins: ['transform-es2015-classes']
+    }).catch(function(err) {
+      expect(err.message).to.equal('fixtures-classes.js was transformed and relies on `classCallCheck`, `inherits`, & `possibleConstructorReturn`, which were not included in the helper whitelist. Either add these helpers to the whitelist or refactor to not be dependent on these runtime helper.');
+    });
+  });
+
+  it('does not throw if helpers are specified', function() {
+    return babel('files', {
+      helperWhiteList: ['classCallCheck', 'possibleConstructorReturn', 'inherits'],
+      plugins: ['transform-es2015-classes']
+    }).then(function(results) {
+      var outputPath = results.directory;
+      var output = fs.readFileSync(path.join(outputPath, 'fixtures-classes.js'), 'utf8');
+      var input = fs.readFileSync(path.join(expectations, 'classes.js'), 'utf8');
+      expect(output).to.eql(input);
+    });
+  });
 });
 
 describe.skip('module metadata', function() {


### PR DESCRIPTION
This PR introduces the idea of declaring what runtime transforms you intend on using. This is meant to be a stick for projects that would like only allow certain runtime helpers to be used.

@Turbo87 😢  No I was not aware of the forking.

/cc @stefanpenner 