### PR TITLE
Remove untested `exportModuleMetadata` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ var scriptTree = esTranspiler(inputTree, {
 });
 ```
 
-`exportModuleMetadata` is an option that can be used to write a JSON file to the output tree that gives you metadata about the tree's imports and exports.
-
 ## Polyfill
 
 In order to use some of the ES6 features you must include the Babel [polyfill](http://babeljs.io/docs/usage/polyfill/#usage-in-browser).

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "broccoli-test-helpers": "0.0.8",
     "chai": "^3.5.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.0.2",
-    "rimraf": "^2.4.2"
+    "mocha": "^3.0.2"
   },
   "publishConfig": {
     "tag": "next"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var fs     = require('fs');
+var fs = require('fs');
 var expect = require('chai').expect;
 var broccoli = require('broccoli');
 var path = require('path');
@@ -8,7 +8,6 @@ var Babel = require('./index');
 var helpers = require('broccoli-test-helpers');
 var stringify = require('json-stable-stringify');
 var mkdirp = require('mkdirp').sync;
-var rm = require('rimraf').sync;
 var makeTestHelper = helpers.makeTestHelper;
 var cleanupBuilders = helpers.cleanupBuilders;
 
@@ -305,126 +304,9 @@ describe('filters files to transform', function() {
   });
 });
 
-describe.skip('module metadata', function() {
-  before(function() {
-    babel = makeTestHelper({
-      subject: function() {
-        return new Babel(arguments[0], arguments[1]);
-      },
-      fixturePath: inputPath
-    });
-  });
-
-  afterEach(function () {
-    return cleanupBuilders();
-  });
-
-  it('exports module metadata', function() {
-    return babel('files', {
-      exportModuleMetadata: true,
-      moduleId: true,
-      modules: 'amdStrict',
-      sourceMap: false,
-      inputSourceMap: false
-    }).then(function(results) {
-      var outputPath = results.directory;
-      var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-      var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
-      expect(output).to.eql(expectation);
-    });
-  });
-
-  it('handles adding and removing files', function() {
-    return babel('files', {
-      exportModuleMetadata: true,
-      moduleId: true,
-      modules: 'amdStrict',
-      sourceMap: false,
-      inputSourceMap: false
-    }).then(function(results) {
-      // Normal build
-      var outputPath = results.directory;
-      var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-      var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
-      expect(output).to.eql(expectation);
-
-      // Move away files/fixtures.js
-      fs.renameSync(path.join(inputPath, 'files', 'fixtures.js'), path.join(inputPath, 'fixtures.js'));
-      return results.builder();
-    }).then(function(results) {
-      // Add back file/fixtures.js
-      fs.renameSync(path.join(inputPath, 'fixtures.js'), path.join(inputPath, 'files', 'fixtures.js'));
-
-      // Build without files/fixtures.js
-      var outputPath = results.directory;
-      var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-      var expectation = fs.readFileSync(path.join(expectations, 'pruned-dep-graph.json'), 'utf8');
-      expect(output).to.eql(expectation);
-
-      return results.builder();
-    }).then(function(results) {
-      // Back to the first build
-      var outputPath = results.directory;
-      var output = fs.readFileSync(path.join(outputPath, 'dep-graph.json'), 'utf8');
-      var expectation = fs.readFileSync(path.join(expectations, 'dep-graph.json'), 'utf8');
-      expect(output).to.eql(expectation);
-    });
-  });
-
-  describe('_generateDepGraph', function() {
-    var tmp = path.join(process.cwd(), 'test-temp');
-    beforeEach(function() {
-      mkdirp(tmp);
-      babel = new Babel('foo');
-      babel.outputPath = tmp;
-    });
-
-    afterEach(function() {
-      rm(tmp);
-      babel.outputPath = null;
-    });
-
-    it('should generate a graph', function() {
-      babel._cache.keys = function() {
-        return ['foo.js', 'bar.js'];
-      };
-
-      babel.moduleMetadata = {
-        foo: {},
-        bar: {}
-      };
-
-      babel._generateDepGraph();
-
-      expect(fs.readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
-        bar: {},
-        foo: {}
-      }, { space: 2 }));
-    });
-
-    it('should evict imports from the graph that are no longer in the tree', function() {
-      babel._cache.keys = function() {
-        return ['foo.js'];
-      };
-
-      babel.moduleMetadata = {
-        foo: {}
-      };
-
-      babel._generateDepGraph();
-
-      expect(fs.readFileSync(path.join(babel.outputPath, 'dep-graph.json'), 'utf8')).to.eql(stringify({
-        foo: {}
-      }, { space: 2 }));
-    });
-  });
-
-});
-
 describe('consume broccoli-babel-transpiler options', function() {
   it('enabled', function() {
     var options = {
-      exportModuleMetadata: true,
       browserPolyfill: true
     };
 
@@ -435,7 +317,6 @@ describe('consume broccoli-babel-transpiler options', function() {
 
   it('explicitly disabled', function() {
     var options = {
-      exportModuleMetadata: false,
       browserPolyfill: false
     };
 


### PR DESCRIPTION
We can always bring this back if it’s deemed useful.