### PR TITLE
Ensure common local plugin options do not error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function Babel(inputTree, _options) {
   Filter.call(this, inputTree, options);
 
   delete options.persist;
+  delete options.annotation;
+  delete options.description;
 
   this.console = options.console || console;
   delete options.console;


### PR DESCRIPTION
Prevents errors from passing through all options to `babel` when using `annotation` / `description` options.

These are used locally by the builder system and should not end up in babel invocation.