### PR TITLE
Caching for plugin objects with baseDir() and cacheKey()

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,12 @@ Babel.prototype.optionsHash = function() {
           // handle native strings, numbers, or null (which can JSON.stringify properly)
           hash.plugins.push(item);
           continue;
+        } else if (type === 'object' && (typeof item.baseDir === 'function')) {
+          hash.plugins.push(hashForDep(item.baseDir()));
+
+          if (typeof item.cacheKey === 'function') {
+            hash.plugins.push(item.cacheKey());
+          }
         } else if (type === 'object') {
           // iterate all keys in the item and push them into the cache
           var keys = Object.keys(item);

--- a/test.js
+++ b/test.js
@@ -646,6 +646,56 @@ describe('when options change', function() {
     expect(firstOptions).to.not.eql(thirdOptions);
   });
 
+  it('plugins can be objects with `baseDir`', function() {
+    var dir = path.join(inputPath, 'plugin-a');
+    var pluginObject = { foo: 'foo' };
+    pluginObject.baseDir = function() { return dir; };
+    options.plugins = [ pluginObject ];
+
+    options.console = fakeConsole;
+    var first = new Babel('foo', options);
+    var firstOptions = first.optionsHash();
+
+    options.console = fakeConsole;
+    var second = new Babel('foo', options);
+    var secondOptions = second.optionsHash();
+
+    expect(firstOptions).to.eql(secondOptions);
+
+    dir = path.join(inputPath, 'plugin-b');
+    options.console = fakeConsole;
+    var third = new Babel('foo', options);
+    var thirdOptions = third.optionsHash();
+
+    expect(firstOptions).to.not.eql(thirdOptions);
+  });
+
+  it('plugins can be objects with `cacheKey`', function() {
+    var dir = path.join(inputPath, 'plugin-a');
+    var key = 'cacheKey1';
+    var pluginObject = { foo: 'foo' };
+    pluginObject.baseDir = function() { return dir; };
+    pluginObject.cacheKey = function() { return key; };
+    options.plugins = [ pluginObject ];
+
+    options.console = fakeConsole;
+    var first = new Babel('foo', options);
+    var firstOptions = first.optionsHash();
+
+    options.console = fakeConsole;
+    var second = new Babel('foo', options);
+    var secondOptions = second.optionsHash();
+
+    expect(firstOptions).to.eql(secondOptions);
+
+    options.console = fakeConsole;
+    key = 'cacheKey3';
+    var third = new Babel('foo', options);
+    var thirdOptions = third.optionsHash();
+
+    expect(firstOptions).to.not.eql(thirdOptions);
+  });
+
   it('a plugins `baseDir` method is used for hash generation', function() {
     var dir = path.join(inputPath, 'plugin-a');
 


### PR DESCRIPTION
This change enables correct caching of parallelizable plugin objects