### PR TITLE
Limit to single worker pool per version of babel-core

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs = require('fs');
 var transpiler = require('babel-core');
 var path = require('path');
 var workerpool = require('workerpool');

--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -16,10 +16,7 @@ var babelCoreVersion = getBabelVersion();
 
 // return the version of Babel that will be used by this plugin
 function getBabelVersion() {
-  var babelCoreRequirePath = require.resolve('babel-core');
-  var babelCorePackageJson = path.join(path.dirname(babelCoreRequirePath), 'package.json');
-  var packageJson = fs.readFileSync(babelCorePackageJson);
-  return JSON.parse(packageJson).version;
+  return require('babel-core/package.json').version;
 }
 
 function getWorkerPool() {

--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var transpiler = require('babel-core');
 var path = require('path');
 var workerpool = require('workerpool');
@@ -8,12 +9,31 @@ var debugGenerator = require('heimdalljs-logger');
 
 var jobs = Number(process.env.JOBS) || require('os').cpus().length;
 
-// create a worker pool using an external worker script
-var pool = workerpool.pool(path.join(__dirname, 'worker.js'), { maxWorkers: jobs });
-
 var loggerName = 'broccoli-persistent-filter:ParallelApi';
 var _logger = debugGenerator(loggerName);
 
+var babelCoreVersion = getBabelVersion();
+
+// return the version of Babel that will be used by this plugin
+function getBabelVersion() {
+  var babelCoreRequirePath = require.resolve('babel-core');
+  var babelCorePackageJson = path.join(path.dirname(babelCoreRequirePath), 'package.json');
+  var packageJson = fs.readFileSync(babelCorePackageJson);
+  return JSON.parse(packageJson).version;
+}
+
+function getWorkerPool() {
+  var pool;
+  var globalPoolID = 'v1/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  var existingPool = process[globalPoolID];
+  if (existingPool) {
+    pool = existingPool;
+  } else {
+    pool = workerpool.pool(path.join(__dirname, 'worker.js'), { maxWorkers: jobs });
+    process[globalPoolID] = pool;
+  }
+  return pool;
+}
 
 function implementsParallelAPI(object) {
   return typeof object._parallelBabel === 'object' &&
@@ -93,6 +113,7 @@ function serializeOptions(options) {
 
 function transformString(string, options) {
   if (transformIsParallelizable(options)) {
+    const pool = getWorkerPool();
     _logger.debug('transformString is parallelizable');
     return pool.exec('transform', [string, serializeOptions(options)]);
   }
@@ -106,6 +127,7 @@ function transformString(string, options) {
 
 module.exports = {
   jobs,
+  getBabelVersion,
   implementsParallelAPI,
   pluginCanBeParallelized,
   pluginsAreParallelizable,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "heimdalljs-logger": "^0.1.7",
     "json-stable-stringify": "^1.0.0",
     "rsvp": "^3.5.0",
-    "workerpool": "^2.2.1"
+    "workerpool": "^2.3.0"
   },
   "devDependencies": {
     "amd-name-resolver": "0.0.6",
@@ -55,7 +55,8 @@
     "broccoli-test-helpers": "0.0.8",
     "chai": "^3.5.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "ps-node": "^0.1.6"
   },
   "engines": {
     "node": ">= 4"

--- a/test.js
+++ b/test.js
@@ -369,6 +369,7 @@ describe('transpile ES6 to ES5', function() {
 });
 
 describe('filters files to transform', function() {
+  this.timeout(5*1000); // some of these are slow in CI
 
   before(function() {
     babel = makeTestHelper({

--- a/test.js
+++ b/test.js
@@ -1303,9 +1303,15 @@ describe('workerpool', function() {
       ParallelApiTwo.transformString(stringToTransform, options),
       ParallelApiTwo.transformString(stringToTransform, options),
     ]).then(() => {
+      // for ps-node,
+      // unix paths look like 'broccoli-babel-transpiler/lib/worker.js'
+      // windows paths look like 'broccoli-babel-transpiler\\lib\\worker.js' (2 path separators)
+      const processMatch = (os.platform() === 'win32')
+        ? 'broccoli-babel-transpiler\\\\lib\\\\worker.js'
+        : path.join('broccoli-babel-transpiler', 'lib', 'worker.js');
       return lookup({
         command: 'node',
-        arguments: path.join('broccoli-babel-transpiler', 'lib', 'worker.js'),
+        arguments: processMatch,
       });
     }).then((resultList) => {
       expect(resultList.length).to.eql(2);

--- a/test.js
+++ b/test.js
@@ -155,11 +155,8 @@ describe('transpile ES6 to ES5', function() {
   });
 
   afterEach(function () {
-    return cleanupBuilders();
-  });
-
-  after(function() {
-    return terminateWorkerPool();
+    return cleanupBuilders()
+      .then(() => terminateWorkerPool);
   });
 
   it('basic', function () {
@@ -791,11 +788,8 @@ describe('on error', function() {
   });
 
   afterEach(function () {
-    return cleanupBuilders();
-  });
-
-  after(function() {
-    return terminateWorkerPool();
+    return cleanupBuilders()
+      .then(() => terminateWorkerPool);
   });
 
   it('returns error from the main process', function () {
@@ -864,7 +858,7 @@ describe('on error', function() {
 
 describe('deserializeOptions()', function() {
 
-  after(function() {
+  afterEach(function() {
     return terminateWorkerPool();
   });
 
@@ -1245,9 +1239,6 @@ describe('concurrency', function() {
     delete require.cache[parallelApiPath];
     delete process.env.JOBS;
     ParallelApi = require('./lib/parallel-api');
-  });
-
-  after(function() {
     return terminateWorkerPool();
   });
 
@@ -1284,7 +1275,8 @@ describe('workerpool', function() {
     ]
   };
 
-  after(function() {
+  afterEach(function() {
+    delete process.env.JOBS;
     return terminateWorkerPool();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,10 @@ connect@^3.3.3:
     parseurl "~1.3.1"
     utils-merge "1.0.0"
 
+connected-domain@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/connected-domain/-/connected-domain-1.0.0.tgz#bfe77238c74be453a79f0cb6058deeb4f2358e93"
+
 convert-source-map@^1.1.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
@@ -884,7 +888,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.1.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -940,6 +944,12 @@ promise-map-series@^0.2.1:
   resolved "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz#c2d377afc93253f6bd03dbb77755eb88ab20a847"
   dependencies:
     rsvp "^3.0.14"
+
+ps-node@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
+  dependencies:
+    table-parser "^0.1.3"
 
 quick-temp@^0.1.2, quick-temp@^0.1.3:
   version "0.1.8"
@@ -1037,6 +1047,12 @@ symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
 
+table-parser@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/table-parser/-/table-parser-0.1.3.tgz#0441cfce16a59481684c27d1b5a67ff15a43c7b0"
+  dependencies:
+    connected-domain "^1.0.0"
+
 "textextensions@1 || 2":
   version "2.1.0"
   resolved "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz#1be0dc2a0dc244d44be8a09af6a85afb93c4dbc3"
@@ -1122,11 +1138,11 @@ wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
-workerpool@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/workerpool/-/workerpool-2.2.1.tgz#41ebff11d5859da948fdb2c850b57da69240988a"
+workerpool@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
   dependencies:
-    object-assign "^4.1.1"
+    object-assign "4.1.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Currently there is one worker pool per installation of broccoli-babel-transpiler. For projects where all dependencies are on the same babel version this is not a problem.

However, when dependencies require a mix of babel 5.x and 6.x (for example during upgrade), this can result in dozens of installations of broccoli-babel-transpiler. Since there is one pool per installation, this results in way too many workers.

This PR limits the number of worker pools to one per version of babel-core. The pool state is stored on the global 'process' as 'v1/broccoli-babel-transpiler/workerpool/babel-core-X.X.X'.