### PR TITLE
CI: Use `skip_cleanup` to not revert `auto-dist-tag` adjustment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ deploy:
   email: stefan.penner+ember-cli@gmail.com
   api_key:
     secure: MGME3tiODyEWOdBlWDXJW8pYbN8Ltz8rgnWSqthv5nCY/oN1SVm0mUOvGydCgoHxtszqUpvfExoBmnD/tcaXXVSzajfAWsa+DDx3zKvAcAbsNRsmPgBuWV8/Ptpq6bglx8kwGHeCatqQgghv0Mm7UrpMEZwbq3u7pzAVjNnUeSo=
+  skip_cleanup: true
   on:
     tags: true
     repo: babel/broccoli-babel-transpiler


### PR DESCRIPTION
Resolves https://github.com/babel/broccoli-babel-transpiler/issues/129

Note that this PR targets the `v5.x` branch where this is most important right now and should be merged upwards eventually.

/cc @stefanpenner 