### PR TITLE
CI: Use `skip_cleanup` to not revert `auto-dist-tag` adjustment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ deploy:
   email: stefan.penner+ember-cli@gmail.com
   api_key:
     secure: MGME3tiODyEWOdBlWDXJW8pYbN8Ltz8rgnWSqthv5nCY/oN1SVm0mUOvGydCgoHxtszqUpvfExoBmnD/tcaXXVSzajfAWsa+DDx3zKvAcAbsNRsmPgBuWV8/Ptpq6bglx8kwGHeCatqQgghv0Mm7UrpMEZwbq3u7pzAVjNnUeSo=
+  skip_cleanup: true
   on:
     tags: true
     repo: babel/broccoli-babel-transpiler


### PR DESCRIPTION
see https://github.com/Turbo87/auto-dist-tag/pull/24