### PR TITLE
Plugins specified as an array of serializable things can be parallelized

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -36,8 +36,21 @@ function implementsParallelAPI(object) {
          typeof object._parallelBabel.requireFile === 'string';
 }
 
+function valueIsSerializable(value) {
+  return value === null ||
+         typeof value === 'string' ||
+         typeof value === 'number' ||
+         typeof value === 'boolean' ||
+         (Array.isArray(value) && value.every(valueIsSerializable)) ||
+         (typeof value === 'object' && Object.keys(value).every(key => valueIsSerializable(value[key])));
+}
+
+function pluginIsSerializableArray(object) {
+  return Array.isArray(object) && object.every(valueIsSerializable);
+}
+
 function pluginCanBeParallelized(plugin) {
-  return typeof plugin === 'string' || implementsParallelAPI(plugin);
+  return typeof plugin === 'string' || implementsParallelAPI(plugin) || pluginIsSerializableArray(plugin);
 }
 
 function pluginsAreParallelizable(plugins) {

--- a/test.js
+++ b/test.js
@@ -1003,12 +1003,17 @@ describe('pluginCanBeParallelized()', function() {
     expect(ParallelApi.pluginCanBeParallelized(function() {})).to.eql(false);
   });
 
-  it('[] - no', function () {
-    expect(ParallelApi.pluginCanBeParallelized([])).to.eql(false);
+  it('[] - yes', function () {
+    expect(ParallelApi.pluginCanBeParallelized([])).to.eql(true);
   });
 
-  it('["plugin-name", { options }] - no', function () {
-    expect(ParallelApi.pluginCanBeParallelized(['plugin-name', {foo: 'bar'}])).to.eql(false);
+  it('[null, "plugin-name", 12, {foo: "bar"}, ["one",2], true, false] - yes', function () {
+    let plugin = [null, "plugin-name", 12, {foo: "bar"}, ["one",2], true, false];
+    expect(ParallelApi.pluginCanBeParallelized(plugin)).to.eql(true);
+  });
+
+  it('["plugin-name", x => x + 1] - no', function () {
+    expect(ParallelApi.pluginCanBeParallelized(['plugin-name', x => x + 1])).to.eql(false);
   });
 
   it('{ _parallelBabel: { requireFile: "a/file" } } - yes', function () {


### PR DESCRIPTION
Babel allows specifying plugins like so:

```javascript
["es2015", { "loose": true, "modules": false }]
```

Plugins setup like this are currently classified as not parallelizable, when they are in fact able to be serialized and passed to the worker processes just fine.

This change recognizes this plugin format and allows these to be parallelized.