### PR TITLE
Add throwUnlessParallelizable (defaulting to false).

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ passed as options to babel must be specified in a serializable form.
 To enable this parallelization there is an API to tell the worker how to
 construct the plugin or callback in its process.
 
+To ensure a build remains parallel safe, one can set the
+`throwUnlessParallelizable` option to true (defaults to false). This will cause
+an error to be thrown, if parallelization is not possible due to an
+incompatible babel plugin.
+
+```js
+new Babel(input, { throwUnlessParallelizable: true | false });
+```
+
 Plugins are specified as an object with a `_parallelBabel` property:
 
 ```js

--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -130,7 +130,13 @@ function serializeOptions(options) {
 }
 
 function transformString(string, options) {
-  if (JOBS > 1 && transformIsParallelizable(options)) {
+  const isParallelizable = transformIsParallelizable(options);
+
+  if (options.throwUnlessParallelizable && !isParallelizable) {
+    throw new Error('BroccoliBabelTranspiler was configured to `throwUnlessParallelizable` and was unable to parallelize an plugin. Please see: https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation for more details');
+  }
+
+  if (JOBS > 1 && isParallelizable) {
     let pool = getWorkerPool();
     _logger.debug('transformString is parallelizable');
     return pool.exec('transform', [string, serializeOptions(options)]);


### PR DESCRIPTION
Someday, after a major version bump we can consider making this true. But to ensure compatibility we will start off as false, but have stuff like ember-cli-babel’s tests choose true. 

Apps may also opt into true