### PR TITLE
Remove 'JOBS=0' from disable parallelization section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,5 @@ JOBS=4 ember build
 To disable parallelization:
 
 ```sh
-JOBS=0 ember build
 JOBS=1 ember build
 ```


### PR DESCRIPTION
The README incorrectly states that setting `JOBS=0` will disable parallelization. The check in [parallel-api.js](https://github.com/babel/broccoli-babel-transpiler/blob/master/lib/parallel-api.js) for the `JOBS` environment variable is:

```
const JOBS = Number(process.env.JOBS) || require('os').cpus().length;
```

`Number(0)` is a falsey value, so setting `JOBS=0` is equivalent to not setting `JOBS` at all, and will default to the number of CPUs. Setting `JOBS=1`  _does_ correctly disable parallelization, so that should be the only suggested approach.