### PR TITLE
Enhance throwUnlessParallelizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ incompatible babel plugin.
 new Babel(input, { throwUnlessParallelizable: true | false });
 ```
 
+Alternatively, an environment variable can be set:
+
+```sh
+THROW_UNLESS_PARALLELIZABLE=1 node build.js
+```
+
 Plugins are specified as an object with a `_parallelBabel` property:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const funnel     = require('broccoli-funnel');
 const crypto     = require('crypto');
 const hashForDep = require('hash-for-dep');
 const transformString = require('./lib/parallel-api').transformString;
-
+const transformIsParallelizable = require('./lib/parallel-api').transformIsParallelizable;
 
 function getExtensionsRegex(extensions) {
   return extensions.map(extension => {
@@ -70,6 +70,11 @@ function Babel(inputTree, _options) {
     this.inputTree = inputTree;
   }
   delete this.options.browserPolyfill;
+
+  if ((this.throwUnlessParallelizable || process.env.THROW_UNLESS_PARALLELIZABLE) && transformIsParallelizable(options) === false) {
+    throw new Error(this.toString() + ' was configured to `throwUnlessParallelizable` and was unable to parallelize an plugin. Please see: https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation for more details');
+  }
+
 }
 
 Babel.prototype = Object.create(Filter.prototype);
@@ -81,9 +86,7 @@ Babel.prototype.baseDir = function() {
 };
 
 Babel.prototype.transform = function(string, options) {
-  return transformString(string, options, {
-    throwUnlessParallelizable: this.throwUnlessParallelizable
-  });
+  return transformString(string, options);
 };
 
 /*

--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -135,10 +135,6 @@ function serializeOptions(options) {
 
 function transformString(string, babelOptions, buildOptions) {
   const isParallelizable = transformIsParallelizable(babelOptions);
-  if (buildOptions !== null && typeof buildOptions === 'object' && buildOptions.throwUnlessParallelizable && !isParallelizable) {
-    throw new Error('BroccoliBabelTranspiler was configured to `throwUnlessParallelizable` and was unable to parallelize an plugin. Please see: https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation for more details');
-  }
-
   if (JOBS > 1 && isParallelizable) {
     let pool = getWorkerPool();
     _logger.debug('transformString is parallelizable');


### PR DESCRIPTION
Throw when the plugin is constructed:

* automatically gives a more actionable stack trace
* fails fast, and fails even if that plugins persistent-filter were to skip the build
* add environment variable