### PR TITLE
Deserialize nested arrays in the parallel API correctly

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -158,7 +158,7 @@ function deserialize(data) {
       if (implementsParallelAPI(member)) {
         result[i] = buildFromParallelApiInfo(member._parallelBabel);
       } else {
-        result[i] = member;
+        result[i] = deserialize(member);
       }
     }
 


### PR DESCRIPTION
@rwjblue Ran into this while fixing tests on the `babel-7` branch of ember-cli-babel, now that it raises an exception if anything isn't parallelizable. Without this change, callbacks passed as plugin options won't be deserialized correctly, since they wind up in a nested array like:

```js
plugins: [
  ['foo-bar', { callback }]
]
```

It looks like the tests on this branch aren't super happy, though...