### PR TITLE
Pass cachekey to worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,8 @@ Babel.prototype.processString = function(string, relativePath) {
     options.moduleId = replaceExtensions(this.extensionsRegex, options.filename);
   }
 
-  return this.transform(string, options)
+  let optionsObj = { 'babel' : options, 'cacheKey' : this._optionsHash};
+  return this.transform(string, optionsObj)
     .then(transpiled => {
       if (this.helperWhiteList) {
         let invalidHelpers = transpiled.metadata.usedHelpers.filter(helper => {

--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -130,7 +130,7 @@ function humanizePlugin(plugin) {
   }
 }
 
-function buildFromParallelApiInfo(parallelApiInfo) {
+function buildFromParallelApiInfo(parallelApiInfo, cacheKey) {
   let requiredStuff = require(parallelApiInfo.requireFile);
 
   if (parallelApiInfo.useMethod) {
@@ -144,21 +144,27 @@ function buildFromParallelApiInfo(parallelApiInfo) {
     if (typeof requiredStuff[parallelApiInfo.buildUsing] !== 'function') {
       throw new Error("'" + parallelApiInfo.buildUsing + "' is not a function in file " + parallelApiInfo.requireFile);
     }
-    return requiredStuff[parallelApiInfo.buildUsing](parallelApiInfo.params);
+    return requiredStuff[parallelApiInfo.buildUsing](parallelApiInfo.params, cacheKey);
   }
 
   return requiredStuff;
 }
 
-function deserialize(data) {
+function deserialize(data, cacheKey) {
+  if (data.cacheKey) {
+    cacheKey = data.cacheKey;
+  }
+  if (data.babel) {
+    data = data.babel;
+  }
   if (Array.isArray(data)) {
     const result = [];
     for (let i =0; i < data.length; i++) {
       let member = data[i];
       if (implementsParallelAPI(member)) {
-        result[i] = buildFromParallelApiInfo(member._parallelBabel);
+        result[i] = buildFromParallelApiInfo(member._parallelBabel, cacheKey);
       } else {
-        result[i] = deserialize(member);
+        result[i] = deserialize(member, cacheKey);
       }
     }
 
@@ -168,14 +174,13 @@ function deserialize(data) {
 
     Object.keys(data).forEach(key => {
       let value = data[key];
-      let valueType = typeof value;
 
       if (value === undefined || value == null) {
 
       } else if (implementsParallelAPI(value)) {
-        value = buildFromParallelApiInfo(value._parallelBabel);
+        value = buildFromParallelApiInfo(value._parallelBabel, cacheKey);
       } else {
-        value = deserialize(value);
+        value = deserialize(value, cacheKey);
       }
       result[key] = value;
     });
@@ -231,12 +236,13 @@ function serialize(options) {
   return serialized;
 }
 
-function transformString(string, babelOptions, buildOptions) {
-  const isParallelizable = transformIsParallelizable(babelOptions).isParallelizable;
+function transformString(string, options, buildOptions) {
+  const isParallelizable = transformIsParallelizable(options.babel).isParallelizable;
   if (JOBS > 1 && isParallelizable) {
     let pool = getWorkerPool();
     _logger.info('transformString is parallelizable');
-    return pool.exec('transform', [string, serialize(babelOptions)]);
+    let serializedObj = { babel : serialize(options.babel), 'cacheKey': options.cacheKey };
+    return pool.exec('transform', [string, serializedObj]);
   } else {
     if (JOBS <= 1) {
       _logger.info('JOBS <= 1, skipping worker, using main thread');
@@ -245,7 +251,7 @@ function transformString(string, babelOptions, buildOptions) {
     }
 
     return new Promise(resolve => {
-      resolve(transpiler.transform(string, deserialize(babelOptions)));
+      resolve(transpiler.transform(string, deserialize(options)));
     });
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -178,14 +178,14 @@ describe('options', function() {
     expect(transpilerOptions).to.eql(undefined);
     babel.processString('path', 'relativePath');
 
-    expect(transpilerOptions.foo).to.eql(1);
-    expect(transpilerOptions.bar.baz).to.eql(1);
+    expect(transpilerOptions.babel.foo).to.eql(1);
+    expect(transpilerOptions.babel.bar.baz).to.eql(1);
 
     options.foo = 2;
     options.bar.baz = 2;
 
-    expect(transpilerOptions.foo).to.eql(1);
-    expect(transpilerOptions.bar.baz).to.eql(1);
+    expect(transpilerOptions.babel.foo).to.eql(1);
+    expect(transpilerOptions.babel.bar.baz).to.eql(1);
   });
 
   it('correct fileName, sourceMapTarget, sourceFileName', function() {
@@ -199,9 +199,9 @@ describe('options', function() {
     expect(transpilerOptions).to.eql(undefined);
     babel.processString('path', 'relativePath');
 
-    expect(transpilerOptions.moduleId).to.eql(undefined);
-    expect(transpilerOptions.filename).to.eql('relativePath');
-    expect(transpilerOptions.sourceFileName).to.eql('relativePath');
+    expect(transpilerOptions.babel.moduleId).to.eql(undefined);
+    expect(transpilerOptions.babel.filename).to.eql('relativePath');
+    expect(transpilerOptions.babel.sourceFileName).to.eql('relativePath');
   });
 
   it('includes moduleId if options.moduleId is true', function() {
@@ -218,7 +218,7 @@ describe('options', function() {
     expect(transpilerOptions).to.eql(undefined);
     babel.processString('path', 'relativePath');
 
-    expect(transpilerOptions.moduleId).to.eql('relativePath');
+    expect(transpilerOptions.babel.moduleId).to.eql('relativePath');
   });
 
   it('does not propagate filterExtensions', function () {
@@ -1443,12 +1443,16 @@ describe('workerpool', function() {
 
   beforeEach(function() {
     options = {
-      inputSourceMap: false,
-      sourceMap: false, plugins: [
-        '@babel/transform-strict-mode',
-        '@babel/transform-block-scoping'
-      ]
+      babel: {
+        inputSourceMap: false,
+        sourceMap: false, plugins: [
+          '@babel/transform-strict-mode',
+          '@babel/transform-block-scoping'
+        ]
+      },
+      cacheKey : "cache-key"
     };
+
   });
 
   afterEach(function() {


### PR DESCRIPTION
The cachekey is passed to worker to avoid calculating the cachekey again in `ember-cli-htmlbars-inline-precompile` 