### PR TITLE
TravisCI: Remove deprecated `sudo: false` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ node_js:
   - "lts/carbon"
   - "10"
 
-sudo: false
-dist: trusty
-
 cache:
   yarn: true
 


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration