### PR TITLE
parallel-api: Fix "Cannot read property '_parallelBabel' of null" error

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -34,7 +34,7 @@ function getWorkerPool() {
 
 function implementsParallelAPI(object) {
   const type = typeof object;
-  const hasProperties = type === 'function' || type === 'object' || Array.isArray(object);
+  const hasProperties = type === 'function' || (type === 'object' && object !== null) || Array.isArray(object);
 
   return hasProperties &&
     object._parallelBabel !== null &&
@@ -191,7 +191,7 @@ const visited = new WeakSet();
 function serialize(options) {
   let optionsType = typeof options;
 
-  if (optionsType === 'object' ||
+  if ((optionsType === 'object' && options !== null) ||
     optionsType === 'function' ||
     Array.isArray(options)) {
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -1312,6 +1312,18 @@ describe('serialize()', function() {
     expect(ParallelApi.serialize(options)).to.eql(options);
   });
 
+  it('does not crash for null', function() {
+    expect(ParallelApi.serialize(null)).to.eql(null);
+  });
+
+  it('does not crash for nested null', function() {
+    let options = {
+      foo: 'bar',
+      baz: null,
+    };
+    expect(ParallelApi.serialize(options)).to.eql(options);
+  });
+
   it('transforms all functions', function() {
     let serialized = ParallelApi.serialize({
       moduleResolve: moduleResolveParallel,


### PR DESCRIPTION
This should resolve #158 

I've targeted the `v6.x` branch, since this bug is not limited to the 7.x release series.

/cc @stefanpenner @rwjblue 