### PR TITLE
Fix browser polyfill for Babel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ const esTranspiler = require('broccoli-babel-transpiler');
 let scriptTree = esTranspiler(inputTree, { browserPolyfill: true });
 ```
 
+By default, the polyfill will appear as `./browser-polyfill.js` in the output
+tree. You can specify a custom output path and filename by supplying a (relative)
+filename in the `browserPolyfillPath` option:
+
+```js
+let scriptTree = esTranspiler(inputTree, {
+  browserPolyfill: true,
+  browserPolyfillPath: 'vendor/polyfill.js'
+})
+```
+
 ## Plugins
 
 Use of custom plugins works similarly to `babel` itself. You would pass a

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/babel/broccoli-babel-transpiler",
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/polyfill": "^7.0.0",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
     "broccoli-persistent-filter": "^1.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,6 +173,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/polyfill@^7.0.0":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
+  integrity sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -616,6 +624,11 @@ copy-concurrently@^1.0.0:
 copy-dereference@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/copy-dereference/-/copy-dereference-1.0.0.tgz#6b131865420fd81b413ba994b44d3655311152b6"
+
+core-js@^2.5.7:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.3.tgz#4b70938bdffdaf64931e66e2db158f0892289c49"
+  integrity sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1599,6 +1612,11 @@ quick-temp@^0.1.2, quick-temp@^0.1.3:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 repeat-string@^1.5.2:
   version "1.6.1"


### PR DESCRIPTION
The Babel polyfill is no longer provided in the @babel/core package but was moved to @babel/polyfill. This updates the plugin to:
* add `@babel/polyfill` as a dependency,
* grab the browser polyfill script from the new package in a platform-agnostic fashion,
* allow the consumer to configure the filename of the polyfill script in the output tree.

Fixes #161 