### PR TITLE
Prevent mismatch between worker and host process.

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -20,7 +20,7 @@ function getBabelVersion() {
 
 function getWorkerPool() {
   let pool;
-  let globalPoolID = 'v1/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let globalPoolID = 'v2/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
   let existingPool = process[globalPoolID];
 
   if (existingPool) {

--- a/tests/utils/terminate-workers.js
+++ b/tests/utils/terminate-workers.js
@@ -5,7 +5,7 @@ let ParallelApi = require('../../lib/parallel-api');
 module.exports = function terminateWorkerPool() {
   // shut down any workerpool that is running at this point
   let babelCoreVersion = ParallelApi.getBabelVersion();
-  let workerPoolId = 'v1/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let workerPoolId = 'v2/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
   let runningPool = process[workerPoolId];
 
   if (runningPool) {


### PR DESCRIPTION
In cd3f22c the interaction between the worker and the parent process changed (moving from referring to just the babel options to a hash of `{ babel, cacheKey }`). In general, this worked well on its own but since we dispatch to a worker pool that may have been setup by a different version of broccoli-babel-transpiler it introduced a mismatch.

Failure scenario:

Run a broccoli pipeline that contains both broccoli-babel-transpiler@7.0.0 and broccoli-babel-transpiler@7.1.0.

1) If the v7.0.0 plugin runs first, the worker pool that is created will **not** be aware of the `.babel` property and therefore it will throw the following error:

```
Unknown option: .babel
```

2) If the v7.1.0 plugin runs first, the worker pool that is created will always attempt to peal off a `.babel` property, but when that pool is being used by a v7.0.0 plugin it would never find the babel options which resulted in completely invalid transpilation output.

The fix here is to increment the global pool identifier to represent the protocol between the "host" and "worker" having changed.

Fixes https://github.com/babel/broccoli-babel-transpiler/issues/156