### PR TITLE
Add dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "in_range"
+    version_requirement_updates: "increase_versions"
+    commit_message:
+      prefix: ""


### PR DESCRIPTION
I'm not sure if the Babel org has dependabot generally enabled yet, but if that happens at some point dependabot will start to bring our dependencies up-to-date.

/cc @hzoo 