### PR TITLE
upgrade workerpool, removes warning of deprecated nodeWorker option

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -26,7 +26,7 @@ function getWorkerPool() {
   if (existingPool) {
     pool = existingPool;
   } else {
-    pool = workerpool.pool(path.join(__dirname, 'worker.js'), { nodeWorker: 'auto', maxWorkers: JOBS });
+    pool = workerpool.pool(path.join(__dirname, 'worker.js'), { workerType: 'auto', maxWorkers: JOBS });
     process[globalPoolID] = pool;
   }
   return pool;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "heimdalljs-logger": "^0.1.9",
     "json-stable-stringify": "^1.0.1",
     "rsvp": "^4.8.4",
-    "workerpool": "^3.1.1"
+    "workerpool": "^5.0.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",


### PR DESCRIPTION
The following warning is visible due to the usage of the deprecated `nodeWorker` option in `workerpool` package.

```
WARNING: Option "nodeWorker" is deprecated since workerpool@5.0.0. Please use "workerType" instead.
```

This PR upgrades the package to the latest version and uses the option `workerType` instead.