### PR TITLE
[feature] adds heimdall monitor for logging information helpful for debugging babel process

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "broccoli-persistent-filter": "^2.2.1",
     "clone": "^2.1.2",
     "hash-for-dep": "^1.4.7",
+    "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.9",
     "json-stable-stringify": "^1.0.1",
     "rsvp": "^4.8.4",


### PR DESCRIPTION
I am working on https://github.com/gabrielcsapo/broccoli-inspector and a feature it has is to surface monitor related information to the user to provide information helpful debugging.

This information will surface the following:

<img width="1011" alt="Screen Shot 2020-05-10 at 7 58 07 PM" src="https://user-images.githubusercontent.com/1854811/81520392-fcdb5a00-92f8-11ea-9b50-8627adf4d778.png">
