### PR TITLE
chore: replace json-stable-stringify with safe-stable-stringify

### DIFF
--- a/lib/options-hash.js
+++ b/lib/options-hash.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stringify  = require('json-stable-stringify');
+const stringify  = require('safe-stable-stringify');
 const crypto = require('crypto');
 const hashForDep = require('hash-for-dep');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hash-for-dep": "^1.4.7",
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.9",
-    "json-stable-stringify": "^1.0.1",
+    "safe-stable-stringify": "^2.2.0",
     "rsvp": "^4.8.4",
     "workerpool": "^6.0.2"
   },


### PR DESCRIPTION
This is a performance improvement as the latter is actually faster.

json-stable-stringify x 13,870 ops/sec ±0.72% (94 runs sampled)
safe-stable-stringify x 30,367 ops/sec ±0.39% (96 runs sampled)

The only difference is that objects with circular reference are from
now on also accepted instead of throwing an error.