### PR TITLE
Support async babel plugins

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -236,35 +236,36 @@ function serialize(options) {
   return serialized;
 }
 
-function transformString(string, options, buildOptions) {
-  const isParallelizable = transformIsParallelizable(options.babel).isParallelizable;
+async function transformString(string, options, buildOptions) {
+  const isParallelizable = transformIsParallelizable(
+    options.babel
+  ).isParallelizable;
   if (JOBS > 1 && isParallelizable) {
     let pool = getWorkerPool();
-    _logger.info('transformString is parallelizable');
-    let serializedObj = { babel : serialize(options.babel), 'cacheKey': options.cacheKey };
-    return pool
-      .exec('transform', [string, serializedObj])
-      .then((result) => {
-        if (result.error) {
-          // when the worker has an error it still resolves, but it has `error`
-          // and `stack` properties instead of `code` + `metadata`
-          //
-          // throw an error to properly fail the "top level" process as needed
-          throw new Error(result.error + result.stack);
-        }
+    _logger.info("transformString is parallelizable");
+    let serializedObj = {
+      babel: serialize(options.babel),
+      cacheKey: options.cacheKey,
+    };
+    let result = await pool.exec("transform", [string, serializedObj]);
 
-        return result;
-      });
-  } else {
-    if (JOBS <= 1) {
-      _logger.info('JOBS <= 1, skipping worker, using main thread');
-    } else {
-      _logger.info('transformString is NOT parallelizable');
+    if (result.error) {
+      // when the worker has an error it still resolves, but it has `error`
+      // and `stack` properties instead of `code` + `metadata`
+      //
+      // throw an error to properly fail the "top level" process as needed
+      throw new Error(result.error + result.stack);
     }
 
-    return new Promise(resolve => {
-      resolve(transpiler.transform(string, deserialize(options)));
-    });
+    return result;
+  } else {
+    if (JOBS <= 1) {
+      _logger.info("JOBS <= 1, skipping worker, using main thread");
+    } else {
+      _logger.info("transformString is NOT parallelizable");
+    }
+
+    return await transpiler.transformAsync(string, deserialize(options));
   }
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -6,22 +6,23 @@ const Promise = require('rsvp').Promise;
 const ParallelApi = require('./parallel-api');
 
 // transpile the input string, using the input options
-function transform(string, options) {
-  return Promise.resolve().then(() => {
-    try {
-      let result = transpiler.transform(string, ParallelApi.deserialize(options));
+async function transform(string, options) {
+  try {
+    let result = await transpiler.transformAsync(
+      string,
+      ParallelApi.deserialize(options)
+    );
 
-      return {
-        code: result.code,
-        metadata: result.metadata
-      };
-    } catch (error) {
-      return {
-        error: error.message,
-        stack: error.stack,
-      };
-    }
-  });
+    return {
+      code: result.code,
+      metadata: result.metadata,
+    };
+  } catch (error) {
+    return {
+      error: error.message,
+      stack: error.stack,
+    };
+  }
 }
 
 // create worker and register public functions

--- a/tests/utils/parallel-plugin.js
+++ b/tests/utils/parallel-plugin.js
@@ -1,0 +1,3 @@
+module.exports = async function() {
+  return { visitor: {} }
+}


### PR DESCRIPTION
This allows people to use async babel plugins and babel plugins authored as ES modules.

It's a relatively small change since this package was already async in the right areas, it was just calling the synchronous babel APIs when it could use the async equivalent.

If we release this as a patch, everybody on ember-cli-babel 8.x will get it.