### PR TITLE
Separate async workpool from earlier sync ones

### DIFF
--- a/lib/parallel-api.js
+++ b/lib/parallel-api.js
@@ -20,7 +20,7 @@ function getBabelVersion() {
 
 function getWorkerPool() {
   let pool;
-  let globalPoolID = 'v2/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let globalPoolID = 'v2/broccoli-babel-transpiler/async-workerpool/babel-core-' + babelCoreVersion;
   let existingPool = process[globalPoolID];
 
   if (existingPool) {

--- a/tests/utils/terminate-workers.js
+++ b/tests/utils/terminate-workers.js
@@ -5,7 +5,7 @@ let ParallelApi = require('../../lib/parallel-api');
 module.exports = function terminateWorkerPool() {
   // shut down any workerpool that is running at this point
   let babelCoreVersion = ParallelApi.getBabelVersion();
-  let workerPoolId = 'v2/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let workerPoolId = 'v2/broccoli-babel-transpiler/async-workerpool/babel-core-' + babelCoreVersion;
   let runningPool = process[workerPoolId];
 
   if (runningPool) {


### PR DESCRIPTION
In 8.0.1 we switched to invoking babel via asynchronous APIs. But this means we don't want to share a workerpool with earlier versions that don't use async APIs, because we cannot safely pass async plugins to those workers.